### PR TITLE
Add stacktrace output when the headless runner catches an error.

### DIFF
--- a/library/resources/runners/headless.js
+++ b/library/resources/runners/headless.js
@@ -45,8 +45,11 @@ p.onConsoleMessage = function(msg) {
     console.log(msg);
 };
 
-p.onError = function(msg) {
+p.onError = function(msg, trace) {
     console.error(msg);
+    trace.forEach(function(t) {
+        console.log(' -> ' + (t.file || t.sourceURL) + ': ' + t.line + (t.function ? ' (in function ' + t.function +')' : ''));
+    });
     exit(1);
 };
 


### PR DESCRIPTION
This just adds a stack trace output, but without source mapping, so you just get the line numbers in compiled JS.
